### PR TITLE
Fixes AWSM-SierraECG for NPM and sets version to 0.1.0

### DIFF
--- a/awsm-sierraecg/awsm.json
+++ b/awsm-sierraecg/awsm.json
@@ -1,6 +1,6 @@
 {
-  "name": "sierraecg",
-  "version": "0.0.1",
+  "name": "awsm-sierraecg",
+  "version": "0.1.0",
   "location": "https://github.com/sixlettervariables/sierra-ecg-tools",
   "author": "Christopher A. Watford (christopher.watford@gmail.com)",
   "description": "Provides SierraECG and PhilipsECG decoding as a web service",

--- a/awsm-sierraecg/awsm/decode/awsm.json
+++ b/awsm-sierraecg/awsm/decode/awsm.json
@@ -12,7 +12,7 @@
           "sierraecg"
         ],
         "includePaths": [
-          "node_modules/awsm-sierraecg/node_modules/sierraecg",
+          "node_modules/awsm-sierraecg/node_modules/sierraecg"
         ]
       },
       "excludePatterns": []

--- a/awsm-sierraecg/package.json
+++ b/awsm-sierraecg/package.json
@@ -1,10 +1,10 @@
 {
   "name": "awsm-sierraecg",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "AWSM for SierraECG",
   "main": "index.js",
   "scripts": {
-    "postinstall" : "jaws postinstall awsm-sierraecg npm",
+    "postinstall": "jaws postinstall awsm-sierraecg npm",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Christopher A. Watford <christopher.watford@gmail.com>",
@@ -27,5 +27,8 @@
   "bugs": {
     "url": "https://github.com/sixlettervariables/sierra-ecg-tools/issues"
   },
-  "homepage": "https://github.com/sixlettervariables/sierra-ecg-tools"
+  "homepage": "https://github.com/sixlettervariables/sierra-ecg-tools",
+  "dependencies": {
+    "sierraecg": "^1.1.1"
+  }
 }


### PR DESCRIPTION
Missed that the `name` in `awsm.json` had not been updated. This (conceptually) fixes AWSM-SierraECG so that it can be used as a standalone module.