### PR TITLE
[BUG] Fix overflow in Python XLI decoding

### DIFF
--- a/pysierraecg/pyproject.toml
+++ b/pysierraecg/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sierraecg"
-version = "0.2.0"
+version = "0.2.1"
 description = "Sierra ECG Tools for Python"
 readme = "README.md"
 authors = [{ name = "Christopher Watford", email = "christopher.watford@gmail.com" }]
@@ -110,7 +110,7 @@ branch = true
 ignore = [".dockerignore", ".editorconfig", "Dockerfile"]
 
 [tool.bumpver]
-current_version = "0.1.0"
+current_version = "0.2.1"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message  = "Bump version {old_version} -> {new_version}"
 commit          = true

--- a/pysierraecg/setup.py
+++ b/pysierraecg/setup.py
@@ -8,7 +8,7 @@ project_dir = Path(__file__).parent
 
 setuptools.setup(
     name="sierraecg",
-    version="0.2.0",
+    version="0.2.1",
     description="Sierra ECG Tools for Python",
     # Use UTF-8 encoding for README even on Windows by using the encoding argument.
     long_description=project_dir.joinpath("README.md").read_text(encoding="utf-8"),

--- a/pysierraecg/src/sierraecg/__init__.py
+++ b/pysierraecg/src/sierraecg/__init__.py
@@ -16,4 +16,4 @@ __all__ = [
     "read_file",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/pysierraecg/src/sierraecg/lib.py
+++ b/pysierraecg/src/sierraecg/lib.py
@@ -77,7 +77,12 @@ def assert_version(elt: Document) -> Tuple[str, str]:
     doc_info = get_node(elt, "documentinfo")
     doc_type = get_text(get_node(doc_info, "documenttype"))
     doc_ver = get_text(get_node(doc_info, "documentversion"))
-    if doc_type not in ["SierraECG", "PhilipsECG"] or doc_ver not in ["1.03", "1.04", "1.04.01"]:
+    if doc_type not in ["SierraECG", "PhilipsECG"] or doc_ver not in [
+        "1.03",
+        "1.04",
+        "1.04.01",
+        "1.04.02",
+    ]:
         raise UnsupportedXmlFileError(f"Files of type {doc_type} {doc_ver} are unsupported")
 
     return (doc_type, doc_ver)

--- a/pysierraecg/src/sierraecg/xli.py
+++ b/pysierraecg/src/sierraecg/xli.py
@@ -35,12 +35,12 @@ def xli_decode(data: bytes, labels: List[str]) -> List[npt.NDArray[np.int16]]:
 
 def xli_decode_deltas(buffer: List[int], first: int) -> npt.NDArray[np.int16]:
     deltas = xli_unpack(buffer)
-    x = deltas[0]
-    y = deltas[1]
+    x = int(deltas[0])
+    y = int(deltas[1])
     last = first
     for i in range(2, len(deltas)):
         z = (y + y) - x - last
-        last = deltas[i] - 64
+        last = int(deltas[i]) - 64
         deltas[i] = z
         x = y
         y = z


### PR DESCRIPTION
Calculation of `z` overflowed when unpacking XLI deltas.

Fixes #47 