### PR TITLE
Address Numpy deprecation warning for out-of-bound integers in xli_unpack

### DIFF
--- a/pysierraecg/src/sierraecg/xli.py
+++ b/pysierraecg/src/sierraecg/xli.py
@@ -52,5 +52,6 @@ def xli_unpack(buffer: List[int]) -> npt.NDArray[np.int16]:
         [0 for _ in range(int(len(buffer) / 2))], dtype=np.int16
     )
     for i in range(len(unpacked)):
-        unpacked[i] = (((buffer[i] << 8) | buffer[len(unpacked) + i]) << 16) >> 16
+        joined_bytes = (((buffer[i] << 8) | buffer[len(unpacked) + i]) << 16) >> 16
+        unpacked[i] = np.array(joined_bytes).astype(np.int16)
     return unpacked


### PR DESCRIPTION
## What
Explicitly casts the result of `xli_unpack` to a `np.int16` to avoid a deprecation warning. Follows the suggestion in the warning to maintain the old behavior, which is to follow C integer overflow logic.

## Why
I started to see a Numpy deprecation warning:
```
./sierra-ecg-tools/pysierraecg/venv/lib/python3.8/site-packages/sierraecg/xli.py:55: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of 65400 to int16 will fail in the future.
For the old behavior, usually:
    np.array(value).astype(dtype)`
will give the desired result (the cast overflows).
  unpacked[i] = (((buffer[i] << 8) | buffer[len(unpacked) + i]) << 16) >> 16
```
which is explained in more detail in the [Numpy 1.24.0 release notes](https://numpy.org/doc/stable/release/1.24.0-notes.html#conversion-of-out-of-bound-python-integers).

To replicate:
```
import warnings
from src.sierraecg import read_file

filepath = "../examples/xml/1_04_01/2020-5-18_15-48-11.xml"

with warnings.catch_warnings():
    warnings.simplefilter("always")
    ecg = read_file(filepath)
```