### PR TITLE
fix: use all remaining bits

### DIFF
--- a/pysierraecg/src/sierraecg/lzw.py
+++ b/pysierraecg/src/sierraecg/lzw.py
@@ -71,8 +71,10 @@ class LzwDecoder(object):
                 self.offset += 1
                 self.bit_buffer |= ((next_byte & 0xFF) << (24 - self.bit_count)) & 0xFFFFFFFF
                 self.bit_count += 8
-            else:
+            elif self.bit_count < self.bits:
                 return -1
+            else:
+                break
 
         code = (self.bit_buffer >> (32 - self.bits)) & 0x0000FFFF
         self.bit_buffer = ((self.bit_buffer & 0xFFFFFFFF) << self.bits) & 0xFFFFFFFF


### PR DESCRIPTION
I tested some examples with pysierraecg. I found one bug and would like to fix it.
There is a problem in the lzw module where the buffer is no longer read even though there are a few (more than 10) bits remaining. So, if the number of bits remaining in the buffer is more than 10, the buffer continues to be read.